### PR TITLE
Removed deprecated image override for dex

### DIFF
--- a/common/dex/base/kustomization.yaml
+++ b/common/dex/base/kustomization.yaml
@@ -9,10 +9,6 @@ resources:
 - service.yaml
 generatorOptions:
   disableNameSuffixHash: true
-images:
-- name: quay.io/dexidp/dex
-  newName: quay.io/dexidp/dex
-  newTag: v2.24.0
 
 secretGenerator:
 - name: dex-oidc-client


### PR DESCRIPTION
The dex image had been updated to a new registry in #2243, thus, making this image override non-functional here.

**Description of your changes:**
I propose removing it here (it's dead code anyhow) and letting only the deployment.yaml refer to the image in question.

**Checklist:**
- [X] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
